### PR TITLE
Slax support

### DIFF
--- a/process_config.sh
+++ b/process_config.sh
@@ -39,7 +39,7 @@ function print_dev_help
 
 function find_partition_for_dir
 {
-    PART=$(df --output=fstype $1 | tail -1)
+	PART=$(df --output=fstype $1 | tail -1)
 	echo $PART
 }
 


### PR DESCRIPTION
These changes allow the benchmarks to run on a slax live iso (which uses a virtual hard drive in ram).

I also confirmed these bechmarks work when you create your own linux live iso/usb with https://github.com/Tomas-M/linux-live

Explanation of changes
 - I simplified find_partition_for_dir, but the only functional change required is the removal of one conditional:  `if [[ "$(echo $curpart | egrep '/')" == "" ]]` because the partition may not have a slash
 - removal of a substring test `match=$(lsblk /dev/$dev | egrep "$PART|$REALPART")`
 - adding zram as an expected prefix

Thanks for building a great tool. I'm looking forward to your feedback and hope you consider incorporating my changes