### PR TITLE
replace deprecated egrep with grep -E

### DIFF
--- a/bandwidth-latency/bandwidth-latency.sh
+++ b/bandwidth-latency/bandwidth-latency.sh
@@ -363,7 +363,7 @@ function get_io {
     fio_outfile=$1-stats.txt
 
     value=$(tail -n 5 $fio_outfile | head -n 2 | \
-		egrep io= | awk '{print $7}')
+		grep -E io= | awk '{print $7}')
     echo $value | sed 's/(//' | sed 's/),//'
 }
 
@@ -630,23 +630,23 @@ function compute_statistics {
 	i_tot_lat_avg=$(awk '{print $11+$15}' < interfered-stats.txt)
 	i_tot_lat_dev=$(awk '{print $12+$16}' < interfered-stats.txt)
 
-	if [[ "$(echo $i_IO_type | egrep read)" != "" ]]; then
+	if [[ "$(echo $i_IO_type | grep -E read)" != "" ]]; then
 	    i_what=reader
 	else
 	    i_what=writer
 	fi
 
-	if [[ "$(echo $i_IO_type | egrep rand)" != "" ]]; then
+	if [[ "$(echo $i_IO_type | grep -E rand)" != "" ]]; then
 	    i_what="rand $i_what"
 	else
 	    i_what="seq $i_what"
 	fi
 
-	I_mix=$(echo ${I_IO_types[@]} | egrep read)
+	I_mix=$(echo ${I_IO_types[@]} | grep -E read)
 
 	if [[ "$I_mix" == "" ]]; then
 	    I_mix=writers
-	elif [[ "$(echo ${I_IO_types[@]} | egrep write)" != "" ]]; then
+	elif [[ "$(echo ${I_IO_types[@]} | grep -E write)" != "" ]]; then
 	    I_mix="readers/writers"
 	else
 	    I_mix=readers
@@ -947,12 +947,12 @@ controller=blkio
 
 # prefer v2 also for prop policy
 if [[ ( "$type_bw_control" == prop && \
-	    "$(mount | egrep "type cgroup2")" != "" ) || \
+	    "$(mount | grep -E "type cgroup2")" != "" ) || \
 	  "$type_bw_control" == low || "$type_bw_control" == lat || \
 	  "$type_bw_control" == cost ]]; then
     # NOTE: cgroups-v2 needed to use low limits or latency/cost controller
     # (cgroups-v2 must be enabled in the kernel)
-    groupdirs=$(mount | egrep ".* on .*blkio.*" | awk '{print $3}')
+    groupdirs=$(mount | grep -E ".* on .*blkio.*" | awk '{print $3}')
     if [[ "$groupdirs" != "" ]]; then
 	umount $groupdirs >/dev/null 2>&1 # to make the io controller available
     fi

--- a/run_multiple_benchmarks/run_main_benchmarks.sh
+++ b/run_multiple_benchmarks/run_main_benchmarks.sh
@@ -192,7 +192,7 @@ function repeat
 
 		if [ "$test_suffix" == startup ] ; then
 			bash $2 "$3" $RES_DIR/$1/repetition$i $4
-		else if [[ "$(echo $1 | egrep latency)" != "" ]]; then
+		else if [[ "$(echo $1 | grep -E latency)" != "" ]]; then
 			 # use eval to handle double quotes in $2
 			 eval $2 -o $RES_DIR/$1/repetition$i
 		     else
@@ -779,7 +779,7 @@ if [[ "${#kern_wl[@]}" -eq "0" ]]; then
     echo "WARNING: no kernel-devel workload left after filtering" >&2
 fi
 
-if [[ "$(echo $BENCHMARKS | egrep replayed)" != "" ]]; then
+if [[ "$(echo $BENCHMARKS | grep -E replayed)" != "" ]]; then
     ../utilities/check_dependencies.sh dd fio iostat bc g++
 
     if [[ $? -ne 0 ]]; then
@@ -800,7 +800,7 @@ if [[ "$(echo $BENCHMARKS | egrep replayed)" != "" ]]; then
 	fi
     fi
     cd $OLDPWD
-elif [[ "$(echo $BENCHMARKS | egrep startup)" != "" ]]; then
+elif [[ "$(echo $BENCHMARKS | grep -E startup)" != "" ]]; then
     ../utilities/check_dependencies.sh dd fio iostat \
 				       xterm gnome-terminal lowriter
     if [[ $? -ne 0 ]]; then
@@ -916,7 +916,7 @@ for sched in $SCHEDULERS; do
 	echo "for $benchmark ($bench_id/$num_benchs)"
 	send_email "$benchmark tests beginning"
 
-	policy_part=$(echo $sched | egrep '^prop-|^low-|^max-|^none-|^lat-')
+	policy_part=$(echo $sched | grep -E '^prop-|^low-|^max-|^none-|^lat-')
 
 	if [[ $benchmark != bandwidth-latency && $benchmark != latency && \
 		  $benchmark != bw-lat-equal-weights && \

--- a/unit_tests/prev_impl.bash
+++ b/unit_tests/prev_impl.bash
@@ -12,7 +12,7 @@ function original_find_partition_for_dir
         do
             curpart=$(echo "$var" | cut -f 1 -d " ")
 
-            if [[ "$(echo $curpart | egrep '/')" == "" ]] && [[ -z "$2" ]]; then
+            if [[ "$(echo $curpart | grep -E '/')" == "" ]] && [[ -z "$2" ]]; then
                 continue
             fi
 

--- a/unit_tests/test_config_scripts.bats
+++ b/unit_tests/test_config_scripts.bats
@@ -49,5 +49,5 @@ load prev_impl
   [ -n "$free_space" ]
 
   # assert is number
-  echo $free_space | egrep -q "^[0-9]+$"
+  echo $free_space | grep -E -q "^[0-9]+$"
 }

--- a/utilities/calc_overall_stats.sh
+++ b/utilities/calc_overall_stats.sh
@@ -96,7 +96,7 @@ function file_loop
 
 	if [[ $res_type =~ latency ]]; then
 	    in_files=$(find $1 -name "bw_lat-$sched---*---${workload_filter}*.txt")
-	    in_files=$(echo $in_files | egrep $sched)
+	    in_files=$(echo $in_files | grep -E $sched)
 	else
 	    in_files=$(find $1 -name "*$sched[-]${workload_filter}*.txt")
 	fi
@@ -351,7 +351,7 @@ function per_subdirectory_loop
 		cat line_file$cur_quant | tee -a $out_file > $REDIRECT
 		second_field=`tail -n 1 $out_file | awk '{print $2}'`
 
-		if [[ $(egrep X number_file$cur_quant) != "" ]]; then
+		if [[ $(grep -E X number_file$cur_quant) != "" ]]; then
 		    echo "         min         max         avg     std_dev" | \
 			tee -a $out_file > $REDIRECT
 		    echo "         X           X           X       X" | \

--- a/utilities/lib_utils.sh
+++ b/utilities/lib_utils.sh
@@ -46,7 +46,7 @@ function test_X_access {
 		# off, save previous access-control state, to re-enable it
 		# again at the end of the test, if needed.
 		XHOST_CONTROL=$($SUDO_PREFIX xhost 2> /dev/null |\
-				egrep "enabled")
+				grep -E "enabled")
 		$SUDO_PREFIX xhost + > /dev/null 2>&1
 
 		if [[ $? -ne 0 ]]; then
@@ -92,7 +92,7 @@ function enable_X_access_and_test_cmd {
 		# off, save previous access-control state, to re-enable it
 		# again at the end of the benchmark, if needed.
 		XHOST_CONTROL=$($SUDO_PREFIX xhost 2> /dev/null |\
-				egrep "enabled")
+				grep -E "enabled")
 		$SUDO_PREFIX xhost + > /dev/null 2>&1
 
 		if [[ $? -ne 0 && "$COMMAND" == "" ]]; then
@@ -110,7 +110,7 @@ function enable_X_access_and_test_cmd {
 
 		$COMMAND >comm_out 2>&1
 		COM_OUT=$?
-		fail_str=$(egrep -i "fail|error|can\'t open display" comm_out)
+		fail_str=$(grep -E -i "fail|error|can\'t open display" comm_out)
 		if [[ $COM_OUT -ne 0 || "$fail_str" != "" ]]; then
 			continue
 		fi
@@ -176,7 +176,7 @@ function restore_scheduler
 	    echo &> /dev/null
 	PIPE_STATUS=${PIPESTATUS[0]}
 	NEW_SCHED=$(cat /sys/block/$dev/queue/scheduler | \
-			egrep "\[$SAVEDSCHED\]")
+			grep -E "\[$SAVEDSCHED\]")
 	if [[ $PIPE_STATUS -ne 0 || "$NEW_SCHED" == "" ]]; then
 	    echo "Restore of $SAVEDSCHED failed:" > /dev/tty
 	    cat /sys/block/$dev/queue/scheduler > /dev/tty
@@ -196,7 +196,7 @@ function set_scheduler
 	    PIPE_STATUS=${PIPESTATUS[0]}
 	    if [[ $(cat /sys/block/$dev/queue/scheduler | wc -w) -gt 1 ]]; then
 		NEW_SCHED=$(cat /sys/block/$dev/queue/scheduler | \
-			    egrep "\[$sched\]")
+			    grep -E "\[$sched\]")
 	    else
 		NEW_SCHED=$(cat /sys/block/$dev/queue/scheduler)
 	    fi

--- a/utilities/plot_stats.sh
+++ b/utilities/plot_stats.sh
@@ -270,11 +270,11 @@ function parse_table
     fi
 
     if [[ "$(echo $in_filename | \
-       egrep ".*latency.*-bw-table.txt")" != "" ]]; then
+       grep -E ".*latency.*-bw-table.txt")" != "" ]]; then
 	plot_bw_lat_bars plot_stacked_bar_subplots.py
 	return
     elif [[ "$(echo $in_filename | \
-		egrep ".*latency.*-lat-table.txt")" != "" ]]; then
+		grep -E ".*latency.*-lat-table.txt")" != "" ]]; then
 	plot_bw_lat_bars plot_bar_errbar_subplots.py
 	return
     fi
@@ -383,9 +383,9 @@ else
     if [ -d "$1" ]; then
 	num_tables_parsed=0
 	for table_file in "$1"/*-table.txt; do
-	    thr_component=$(echo $table_file | egrep throughput)
-	    startup_component=$(echo $table_file | egrep startup)
-	    video_component=$(echo $table_file | egrep video)
+	    thr_component=$(echo $table_file | grep -E throughput)
+	    startup_component=$(echo $table_file | grep -E startup)
+	    video_component=$(echo $table_file | grep -E video)
 
 	    if [[ "$thr_component" != "" && \
 		    ( "$startup_component" != "" || "$video_component" != "" ) ]]
@@ -425,7 +425,7 @@ else
 fi
 
 if [[ "$(echo $1 | \
-       egrep ".*latency.*-bw-table.txt")" != "" ]]; then
+       grep -E ".*latency.*-bw-table.txt")" != "" ]]; then
     exit
 fi
 type gnuplot >/dev/null 2>&1


### PR DESCRIPTION
`egrep` is the same as `grep -E` but direct invocation as `egrep` is deprecated and is only provided to allow historical applications that rely on it to run unmodified. This change modifies 8 files to use `grep -E` instead by replacing all instances of `egrep` with `grep -E` . I don't believe this commit will cause any problems but I'll admit I haven't tested it. It should reduce the number of warning messages.